### PR TITLE
Fixed match.group error

### DIFF
--- a/mjml/helpers/shorthand_parser.py
+++ b/mjml/helpers/shorthand_parser.py
@@ -36,6 +36,9 @@ def shorthandParser(cssValue, direction):
 def borderParser(border):
     border_regex = re.compile('(?:(?:^| )(\d+))')
     match = border_regex.search(border)
-    border_value = match.group(1)
-    return parse_int(border_value or '0')
+    try:
+        border_value = match.group(1)
+    except:
+        border_value = 0
+    return parse_int(border_value)
 


### PR DESCRIPTION
When parsing this template https://github.com/mjmlio/email-templates/blob/master/templates/welcome-email.mjml

the helper borderParser function throws the error

AttributeError: 'NoneType' object has no attribute 'group'

	modified:   shorthand_parser.py