### PR TITLE
Add support for CSS inlining

### DIFF
--- a/mjml/elements/head/mj_style.py
+++ b/mjml/elements/head/mj_style.py
@@ -14,7 +14,5 @@ class MjStyle(HeadComponent):
     def handler(self):
         add = self.context['add']
         inline_attr = 'inlineStyle' if (self.get_attr('inline') == 'inline') else 'style'
-        if inline_attr == 'inlineStyle':
-            raise NotImplementedError('style inlining not supported yet')
         add(inline_attr, self.getContent())
 

--- a/mjml/mjml2html.py
+++ b/mjml/mjml2html.py
@@ -2,7 +2,6 @@
 from io import BytesIO, StringIO
 from pathlib import Path, PurePath
 
-import css_inline
 from lxml import etree as lxml_etree
 
 from .core import initComponent
@@ -211,6 +210,11 @@ def mjml_to_html(xml_fp_or_json, skeleton=None, template_dir=None):
     # LATER: upstream has also minify
 
     if len(globalDatas.inlineStyle) > 0:
+        try:
+            import css_inline
+        except ImportError:
+            raise ImportError('CSS inlining is an optional feature. Run `pip install -e ".[css_inlining]"` to install the required dependencies.')
+
         inliner = css_inline.CSSInliner(inline_style_tags=False, extra_css=''.join(globalDatas.inlineStyle))
         content = inliner.inline(content)
 

--- a/mjml/mjml2html.py
+++ b/mjml/mjml2html.py
@@ -2,6 +2,7 @@
 from io import BytesIO, StringIO
 from pathlib import Path, PurePath
 
+import css_inline
 from lxml import etree as lxml_etree
 
 from .core import initComponent
@@ -208,6 +209,10 @@ def mjml_to_html(xml_fp_or_json, skeleton=None, template_dir=None):
     )
     # LATER: upstream has also beautify
     # LATER: upstream has also minify
+
+    if len(globalDatas.inlineStyle) > 0:
+        inliner = css_inline.CSSInliner(inline_style_tags=False, extra_css=''.join(globalDatas.inlineStyle))
+        content = inliner.inline(content)
 
     content = mergeOutlookConditionnals(content)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ zip_safe = true
 include_package_data = true
 
 install_requires =
-	css_inline
 	docopt
 	jinja2
 	lxml
@@ -55,6 +54,8 @@ testing =
 	FakeFSHelpers
 	HTMLCompare >= 0.3.0        # >= 0.3.0: ability to ignore attribute ordering in HTML
 	PythonicTestcase
+css_inlining =
+	css_inline
 
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ zip_safe = true
 include_package_data = true
 
 install_requires =
+	css_inline
 	docopt
 	jinja2
 	lxml

--- a/tests/testdata/hello-world-expected.html
+++ b/tests/testdata/hello-world-expected.html
@@ -124,7 +124,7 @@
                       </td>
                     </tr>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                      <td align="left" class="box" style="font-size:0px;padding:10px 25px;word-break:break-word;border: 5px solid red">
                         <div style="font-family:helvetica;font-size:20px;line-height:1;text-align:left;color:#F45E43;">Hello World</div>
                       </td>
                     </tr>

--- a/tests/testdata/hello-world.mjml
+++ b/tests/testdata/hello-world.mjml
@@ -1,4 +1,11 @@
 <mjml>
+  <mj-head>
+    <mj-style inline="inline">
+      .box {
+        border: 5px solid red;
+      }
+    </mj-style>
+  </mj-head>
   <mj-body>
     <mj-section>
       <mj-column>
@@ -7,7 +14,7 @@
 
         <mj-divider border-color="#F45E43"></mj-divider>
 
-        <mj-text font-size="20px" color="#F45E43" font-family="helvetica">Hello World</mj-text>
+        <mj-text css-class="box" font-size="20px" color="#F45E43" font-family="helvetica">Hello World</mj-text>
 
       </mj-column>
     </mj-section>


### PR DESCRIPTION
Addresses #1.

~Things to note: css-inliner doesn't currently support styles with the `!important` rule (https://github.com/Stranger6667/css-inline/issues/152). I have an [open PR](https://github.com/Stranger6667/css-inline/pull/153) to add support.~
`!important` support has been added to css-inliner.