### PR TITLE
Add support for custom components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ------------------
 
 - add mjml-head-breakpoint, mjml-navbar, mjml-navbar-link, mjml-spacer, and mjml-wrapper components (Casey Holzer)
+- add support for custom components (Casey Holzer)
 
 
 0.8.0 (2022-08-25)

--- a/mjml/core/api.py
+++ b/mjml/core/api.py
@@ -1,7 +1,7 @@
 
 from ..lib import merge_dicts, AttrDict
 
-from .registry import _components
+from .registry import components
 
 
 __all__ = ['initComponent', 'Component']
@@ -9,7 +9,6 @@ __all__ = ['initComponent', 'Component']
 def initComponent(name, **initialDatas):
     if name is None:
         return None
-    components = _components()
     component_cls = components[name]
     if not component_cls:
         return None

--- a/mjml/core/registry.py
+++ b/mjml/core/registry.py
@@ -1,20 +1,18 @@
 
 
-__all__ = ['assign_components', 'components', 'handle_mjml_config_components', 'preset_core_components', 'register_component']
+__all__ = ['components', 'register_components', 'register_core_components']
 
-import inspect
-from types import ModuleType
-from typing import Type
+from typing import List, Type
 
 components = {}
 
-def preset_core_components():
+def register_core_components():
     from ..elements import (MjButton, MjText, MjSection, MjColumn, MjBody,
         MjGroup, MjImage, MjNavbar, MjNavbarLink, MjDivider, MjSpacer, MjTable, MjRaw, MjWrapper)
     from ..elements.head import (MjAttributes, MjBreakpoint, MjFont, MjHead, MjPreview, MjStyle,
         MjTitle)
 
-    assign_components(components, [
+    register_components([
         MjButton,
         MjText,
         MjDivider,
@@ -41,29 +39,7 @@ def preset_core_components():
 
     return components
 
-def assign_components(target, source):
+
+def register_components(source: List[Type]):
     for component in source:
-        target[component.component_name] = component
-
-
-def register_component(Component: Type):
-    assign_components(components, [Component])
-
-
-def register_custom_component(
-    comp,
-    registerCompFn=register_component,
-):
-    try:
-        registerCompFn(comp)
-    except AttributeError:
-        if isinstance(comp, ModuleType):
-            # Convert module into list of submodules
-            comp = list([cls for name, cls in inspect.getmembers(comp) if inspect.isclass(cls)])
-
-        for component in comp:
-            register_custom_component(component, registerCompFn)
-
-
-def handle_mjml_config_components(components):
-    register_custom_component(components)
+        components[component.component_name] = component

--- a/mjml/core/registry.py
+++ b/mjml/core/registry.py
@@ -1,10 +1,14 @@
 
 
-__all__ = []
+__all__ = ['assign_components', 'components', 'handle_mjml_config_components', 'preset_core_components', 'register_component']
+
+import inspect
+from types import ModuleType
+from typing import Type
 
 components = {}
 
-def _components():
+def preset_core_components():
     from ..elements import (MjButton, MjText, MjSection, MjColumn, MjBody,
         MjGroup, MjImage, MjNavbar, MjNavbarLink, MjDivider, MjSpacer, MjTable, MjRaw, MjWrapper)
     from ..elements.head import (MjAttributes, MjBreakpoint, MjFont, MjHead, MjPreview, MjStyle,
@@ -40,3 +44,26 @@ def _components():
 def assign_components(target, source):
     for component in source:
         target[component.component_name] = component
+
+
+def register_component(Component: Type):
+    assign_components(components, [Component])
+
+
+def register_custom_component(
+    comp,
+    registerCompFn=register_component,
+):
+    try:
+        registerCompFn(comp)
+    except AttributeError:
+        if isinstance(comp, ModuleType):
+            # Convert module into list of submodules
+            comp = list([cls for name, cls in inspect.getmembers(comp) if inspect.isclass(cls)])
+
+        for component in comp:
+            register_custom_component(component, registerCompFn)
+
+
+def handle_mjml_config_components(components):
+    register_custom_component(components)

--- a/mjml/core/registry.py
+++ b/mjml/core/registry.py
@@ -2,33 +2,41 @@
 
 __all__ = []
 
+components = {}
+
 def _components():
     from ..elements import (MjButton, MjText, MjSection, MjColumn, MjBody,
         MjGroup, MjImage, MjNavbar, MjNavbarLink, MjDivider, MjSpacer, MjTable, MjRaw, MjWrapper)
     from ..elements.head import (MjAttributes, MjBreakpoint, MjFont, MjHead, MjPreview, MjStyle,
         MjTitle)
-    components = {
-        'mj-button': MjButton,
-        'mj-text': MjText,
-        'mj-divider': MjDivider,
-        'mj-image': MjImage,
-        'mj-section': MjSection,
-        'mj-column': MjColumn,
-        'mj-body': MjBody,
-        'mj-group'  : MjGroup,
-        'mj-table'  : MjTable,
-        'mj-raw'  : MjRaw,
-        'mj-navbar': MjNavbar,
-        'mj-navbar-link': MjNavbarLink,
-        'mj-spacer': MjSpacer,
-        'mj-wrapper': MjWrapper,
+
+    assign_components(components, [
+        MjButton,
+        MjText,
+        MjDivider,
+        MjImage,
+        MjSection,
+        MjColumn,
+        MjBody,
+        MjGroup,
+        MjTable,
+        MjRaw,
+        MjNavbar,
+        MjNavbarLink,
+        MjSpacer,
+        MjWrapper,
         # --- head components ---
-        'mj-attributes': MjAttributes,
-        'mj-font': MjFont,
-        'mj-head': MjHead,
-        'mj-preview': MjPreview,
-        'mj-title': MjTitle,
-        'mj-style': MjStyle,
-        'mj-breakpoint': MjBreakpoint,
-    }
+        MjAttributes,
+        MjFont,
+        MjHead,
+        MjPreview,
+        MjTitle,
+        MjStyle,
+        MjBreakpoint,
+    ])
+
     return components
+
+def assign_components(target, source):
+    for component in source:
+        target[component.component_name] = component

--- a/mjml/elements/_base.py
+++ b/mjml/elements/_base.py
@@ -2,7 +2,7 @@
 
 from ..lib import merge_dicts, AttrDict
 from ..core import initComponent, Component
-from ..core.registry import _components
+from ..core.registry import components
 from ..helpers import *
 
 
@@ -111,7 +111,7 @@ class BodyComponent(Component):
         #  child => !find(rawComponents, c => c.getTagName() === child.tagName),
         #).length
         raw_tag_names = set()
-        for tag_name, component in _components().items():
+        for tag_name, component in components.items():
             if component.isRawElement():
                 raw_tag_names.add(tag_name)
         is_raw_element = lambda c: (c['tagName'] in raw_tag_names)

--- a/mjml/elements/head/mj_attributes.py
+++ b/mjml/elements/head/mj_attributes.py
@@ -6,6 +6,8 @@ from mjml.helpers import omit
 __all__ = ['MjAttributes']
 
 class MjAttributes(HeadComponent):
+    component_name = 'mj-attributes'
+
     def handler(self):
         add = self.context['add']
         _children = self.props.children

--- a/mjml/elements/head/mj_breakpoint.py
+++ b/mjml/elements/head/mj_breakpoint.py
@@ -6,6 +6,8 @@ __all__ = ['MjBreakpoint']
 
 
 class MjBreakpoint(HeadComponent):
+    component_name = 'mj-breakpoint'
+
     @classmethod
     def allowed_attrs(cls):
         return {

--- a/mjml/elements/head/mj_font.py
+++ b/mjml/elements/head/mj_font.py
@@ -6,6 +6,8 @@ __all__ = ['MjFont']
 
 
 class MjFont(HeadComponent):
+    component_name = 'mj-font'
+
     @classmethod
     def allowed_attrs(cls):
         return {

--- a/mjml/elements/head/mj_head.py
+++ b/mjml/elements/head/mj_head.py
@@ -5,6 +5,8 @@ from ._head_base import HeadComponent
 __all__ = ['MjHead']
 
 class MjHead(HeadComponent):
+    component_name = 'mj-head'
+
     def handler(self):
         return self.handlerChildren()
 

--- a/mjml/elements/head/mj_preview.py
+++ b/mjml/elements/head/mj_preview.py
@@ -6,6 +6,7 @@ __all__ = ['MjPreview']
 
 
 class MjPreview(HeadComponent):
+    component_name = 'mj-preview'
 
     def handler(self):
         add = self.context['add']

--- a/mjml/elements/head/mj_style.py
+++ b/mjml/elements/head/mj_style.py
@@ -5,6 +5,8 @@ from ._head_base import HeadComponent
 __all__ = ['MjStyle']
 
 class MjStyle(HeadComponent):
+    component_name = 'mj-style'
+
     @classmethod
     def default_attrs(cls):
         return {

--- a/mjml/elements/head/mj_title.py
+++ b/mjml/elements/head/mj_title.py
@@ -5,6 +5,8 @@ from ._head_base import HeadComponent
 __all__ = ['MjTitle']
 
 class MjTitle(HeadComponent):
+    component_name = 'mj-title'
+
     def handler(self):
         add = self.context['add']
         add('title', self.getContent())

--- a/mjml/elements/mj_body.py
+++ b/mjml/elements/mj_body.py
@@ -6,6 +6,8 @@ from ..lib import merge_dicts
 __all__ = ['MjBody']
 
 class MjBody(BodyComponent):
+    component_name = 'mj-body'
+
     @classmethod
     def allowed_attrs(cls):
         return {

--- a/mjml/elements/mj_button.py
+++ b/mjml/elements/mj_button.py
@@ -6,6 +6,8 @@ from ..helpers import widthParser
 __all__ = ['MjButton']
 
 class MjButton(BodyComponent):
+    component_name = 'mj-button'
+
     @classmethod
     def allowed_attrs(cls):
         return {

--- a/mjml/elements/mj_column.py
+++ b/mjml/elements/mj_column.py
@@ -212,8 +212,8 @@ class MjColumn(BodyComponent):
                 class_ = component.getAttribute('css-class', missing_ok=True),
                 style = {
                     'background': component.getAttribute(
-                      'container-background-color',
-                        True
+                        'container-background-color',
+                        missing_ok=True
                     ),
                     'font-size': '0px',
                     'padding': component.getAttribute('padding'),

--- a/mjml/elements/mj_column.py
+++ b/mjml/elements/mj_column.py
@@ -7,6 +7,8 @@ from ..lib import merge_dicts
 __all__ = ['MjColumn']
 
 class MjColumn(BodyComponent):
+    component_name = 'mj-column'
+
     @classmethod
     def allowed_attrs(cls):
         return {

--- a/mjml/elements/mj_divider.py
+++ b/mjml/elements/mj_divider.py
@@ -7,6 +7,8 @@ from ..lib import merge_dicts
 __all__ = ['MjDivider']
 
 class MjDivider(BodyComponent):
+    component_name = 'mj-divider'
+
     @classmethod
     def allowed_attrs(cls):
         return {

--- a/mjml/elements/mj_group.py
+++ b/mjml/elements/mj_group.py
@@ -7,6 +7,8 @@ from ..lib import merge_dicts
 __all__ = ['MjGroup']
 
 class MjGroup(BodyComponent):
+    component_name = 'mj-group'
+
     @classmethod
     def default_attrs(cls):
         return {

--- a/mjml/elements/mj_image.py
+++ b/mjml/elements/mj_image.py
@@ -8,6 +8,8 @@ from ..helpers import parse_int, strip_unit, widthParser
 __all__ = ['MjImage']
 
 class MjImage(BodyComponent):
+    component_name = 'mj-image'
+
     @classmethod
     def allowed_attrs(cls):
         return {

--- a/mjml/elements/mj_navbar.py
+++ b/mjml/elements/mj_navbar.py
@@ -9,6 +9,8 @@ __all__ = ['MjNavbar']
 
 
 class MjNavbar(BodyComponent):
+    component_name = 'mj-navbar'
+
     @classmethod
     def allowed_attrs(cls):
         return {

--- a/mjml/elements/mj_navbar_link.py
+++ b/mjml/elements/mj_navbar_link.py
@@ -7,6 +7,8 @@ __all__ = ['MjNavbarLink']
 
 
 class MjNavbarLink(BodyComponent):
+    component_name = 'mj-navbar-link'
+
     @classmethod
     def allowed_attrs(cls):
         return {

--- a/mjml/elements/mj_raw.py
+++ b/mjml/elements/mj_raw.py
@@ -6,6 +6,8 @@ __all__ = ['MjRaw']
 
 
 class MjRaw(BodyComponent):
+    component_name = 'mj-raw'
+
     rawElement = True
 
     def render(self):

--- a/mjml/elements/mj_section.py
+++ b/mjml/elements/mj_section.py
@@ -246,7 +246,7 @@ class MjSection(BodyComponent):
             if component.isRawElement():
                 return component.render()
             td_ie_attrs = component.html_attrs(
-                align=component.get_attr('align', True),
+                align=component.get_attr('align', missing_ok=True),
                 class_=suffixCssClasses(
                       component.get_attr('css-class'),
                       'outlook',

--- a/mjml/elements/mj_section.py
+++ b/mjml/elements/mj_section.py
@@ -14,6 +14,8 @@ Position = namedtuple('Position', ('x', 'y'))
 
 
 class MjSection(BodyComponent):
+    component_name = 'mj-section'
+
     @classmethod
     def allowed_attrs(cls):
         return {

--- a/mjml/elements/mj_spacer.py
+++ b/mjml/elements/mj_spacer.py
@@ -6,6 +6,8 @@ __all__ = ['MjSpacer']
 
 
 class MjSpacer(BodyComponent):
+    component_name = 'mj-spacer'
+
     @classmethod
     def allowed_attrs(cls):
         return {

--- a/mjml/elements/mj_table.py
+++ b/mjml/elements/mj_table.py
@@ -6,6 +6,8 @@ from ..helpers import widthParser
 __all__ = ['MjTable']
 
 class MjTable(BodyComponent):
+    component_name = 'mj-table'
+
     @classmethod
     def allowed_attrs(cls):
         return {

--- a/mjml/elements/mj_text.py
+++ b/mjml/elements/mj_text.py
@@ -5,6 +5,8 @@ from ._base import BodyComponent
 __all__ = ['MjText']
 
 class MjText(BodyComponent):
+    component_name = 'mj-text'
+
     @classmethod
     def allowed_attrs(cls):
         return {

--- a/mjml/elements/mj_wrapper.py
+++ b/mjml/elements/mj_wrapper.py
@@ -17,7 +17,7 @@ class MjWrapper(MjSection):
             if component.isRawElement():
                 return component.render()
             td_ie_attrs = component.html_attrs(
-                align=component.get_attr('align', True),
+                align=component.get_attr('align', missing_ok=True),
                 class_=suffixCssClasses(
                       component.get_attr('css-class'),
                       'outlook',

--- a/mjml/elements/mj_wrapper.py
+++ b/mjml/elements/mj_wrapper.py
@@ -7,6 +7,8 @@ __all__ = ['MjWrapper']
 
 
 class MjWrapper(MjSection):
+    component_name = 'mj-wrapper'
+
     def renderWrappedChildren(self):
         children = self.props['children']
         containerWidth = self.context['containerWidth']

--- a/mjml/mjml2html.py
+++ b/mjml/mjml2html.py
@@ -1,11 +1,12 @@
 
 from io import BytesIO, StringIO
 from pathlib import Path, PurePath
+from typing import List, Type
 
 from bs4 import BeautifulSoup
 
 from .core import initComponent
-from .core.registry import handle_mjml_config_components, preset_core_components
+from .core.registry import register_components, register_core_components
 from .helpers import mergeOutlookConditionnals, json_to_xml, omit, skeleton_str as default_skeleton
 from .lib import merge_dicts, AttrDict
 
@@ -18,8 +19,8 @@ def ignore_empty(values):
     return tuple(result)
 
 
-def mjml_to_html(xml_fp_or_json, skeleton=None, template_dir=None, custom_components=None):
-    preset_core_components()
+def mjml_to_html(xml_fp_or_json, skeleton=None, template_dir=None, custom_components: List[Type] = None):
+    register_core_components()
 
     if isinstance(xml_fp_or_json, dict):
         xml_fp = StringIO(json_to_xml(xml_fp_or_json))
@@ -40,7 +41,7 @@ def mjml_to_html(xml_fp_or_json, skeleton=None, template_dir=None, custom_compon
     skeleton = default_skeleton
 
     if custom_components:
-        handle_mjml_config_components(custom_components)
+        register_components(custom_components)
 
     fonts = {
       'Open Sans': 'https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700',

--- a/mjml/mjml2html.py
+++ b/mjml/mjml2html.py
@@ -5,6 +5,7 @@ from pathlib import Path, PurePath
 from bs4 import BeautifulSoup
 
 from .core import initComponent
+from .core.registry import handle_mjml_config_components, preset_core_components
 from .helpers import mergeOutlookConditionnals, json_to_xml, omit, skeleton_str as default_skeleton
 from .lib import merge_dicts, AttrDict
 
@@ -17,7 +18,9 @@ def ignore_empty(values):
     return tuple(result)
 
 
-def mjml_to_html(xml_fp_or_json, skeleton=None, template_dir=None):
+def mjml_to_html(xml_fp_or_json, skeleton=None, template_dir=None, custom_components=None):
+    preset_core_components()
+
     if isinstance(xml_fp_or_json, dict):
         xml_fp = StringIO(json_to_xml(xml_fp_or_json))
     elif isinstance(xml_fp_or_json, str):
@@ -35,6 +38,9 @@ def mjml_to_html(xml_fp_or_json, skeleton=None, template_dir=None):
     if skeleton_path:
         raise NotImplementedError('not yet implemented')
     skeleton = default_skeleton
+
+    if custom_components:
+        handle_mjml_config_components(custom_components)
 
     fonts = {
       'Open Sans': 'https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700',

--- a/tests/custom/__init__.py
+++ b/tests/custom/__init__.py
@@ -1,3 +1,0 @@
-
-from .mj_text_custom import *
-from .mj_text_override import *

--- a/tests/custom/__init__.py
+++ b/tests/custom/__init__.py
@@ -1,0 +1,3 @@
+
+from .mj_text_custom import *
+from .mj_text_override import *

--- a/tests/custom/mj_text_custom.py
+++ b/tests/custom/mj_text_custom.py
@@ -1,0 +1,12 @@
+from mjml.elements import MjText
+
+__all__ = ['MjTextCustom']
+
+
+class MjTextCustom(MjText):
+    component_name = 'mj-text-custom'
+
+    def render(self):
+        content = super().render()
+
+        return f'<div>START CUSTOM WRAPPER</div>{content}<div>END CUSTOM WRAPPER</div>'

--- a/tests/custom/mj_text_override.py
+++ b/tests/custom/mj_text_override.py
@@ -1,0 +1,20 @@
+from mjml.elements import MjText
+
+__all__ = ['MjTextOverride']
+
+
+class MjTextOverride(MjText):
+    @classmethod
+    def default_attrs(cls):
+        attrs = super().default_attrs()
+        return {
+            **attrs,
+            'align'            : 'right',
+            'color'            : 'red',
+            'font-size'        : '26px',
+        }
+
+    def render(self):
+        content = super().render()
+
+        return f'<div>***</div>{content}<div>***</div>'

--- a/tests/testdata/_custom-expected.html
+++ b/tests/testdata/_custom-expected.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+  <title>
+  </title>
+  <!--[if !mso]><!-->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <!--<![endif]-->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style type="text/css">
+    #outlook a {
+      padding: 0;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+
+    table,
+    td {
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+
+    img {
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+    }
+
+    p {
+      display: block;
+      margin: 13px 0;
+    }
+
+  </style>
+  <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+  <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+  <!--[if !mso]><!-->
+  <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+  <style type="text/css">
+    @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+
+  </style>
+  <!--<![endif]-->
+  <style type="text/css">
+    @media only screen and (min-width:480px) {
+      .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
+      }
+    }
+
+  </style>
+  <style media="screen and (min-width:480px)">
+    .moz-text-html .mj-column-per-100 {
+      width: 100% !important;
+      max-width: 100%;
+    }
+
+  </style>
+  <style type="text/css">
+  </style>
+  <style type="text/css">
+  </style>
+</head>
+
+<body style="word-spacing:normal;">
+  <div style="">
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                  <tbody>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                        <div>START CUSTOM WRAPPER</div><div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is a new component</div><div>END CUSTOM WRAPPER</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="right" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                        <div>***</div><div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:26px;line-height:1;text-align:right;color:red;">This component has been changed</div><div>***</div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+  </div>
+</body>
+
+</html>

--- a/tests/testdata/_custom.mjml
+++ b/tests/testdata/_custom.mjml
@@ -1,0 +1,10 @@
+<mjml>
+  <mj-body>
+    <mj-section>
+      <mj-column>
+        <mj-text-custom>This is a new component</mj-text-custom>
+        <mj-text>This component has been changed</mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/tests/upstream_alignment_test.py
+++ b/tests/upstream_alignment_test.py
@@ -130,20 +130,14 @@ class UpstreamAlignmentTest(TestCase):
         assert (b'foo <b>bar</b>.' == actual_html)
 
     def test_custom_components(self):
-        import custom as custom_components
         from custom.mj_text_custom import MjTextCustom
         from custom.mj_text_override import MjTextOverride
         expected_html = load_expected_html('_custom')
         with get_mjml_fp('_custom') as mjml_fp:
-            result_module = mjml_to_html(mjml_fp, custom_components=custom_components)
-        with get_mjml_fp('_custom') as mjml_fp:
             result_list = mjml_to_html(mjml_fp, custom_components=[MjTextCustom, MjTextOverride])
 
-        assert not result_module.errors
         assert not result_list.errors
-        module_actual_html = result_module.html
         list_actual_html = result_list.html
-        assert_same_html(expected_html, module_actual_html, verbose=True)
         assert_same_html(expected_html, list_actual_html, verbose=True)
 
 

--- a/tests/upstream_alignment_test.py
+++ b/tests/upstream_alignment_test.py
@@ -129,6 +129,23 @@ class UpstreamAlignmentTest(TestCase):
         actual_html = (body_actual.select('table > tr > td > div')[0]).renderContents()
         assert (b'foo <b>bar</b>.' == actual_html)
 
+    def test_custom_components(self):
+        import custom as custom_components
+        from custom.mj_text_custom import MjTextCustom
+        from custom.mj_text_override import MjTextOverride
+        expected_html = load_expected_html('_custom')
+        with get_mjml_fp('_custom') as mjml_fp:
+            result_module = mjml_to_html(mjml_fp, custom_components=custom_components)
+        with get_mjml_fp('_custom') as mjml_fp:
+            result_list = mjml_to_html(mjml_fp, custom_components=[MjTextCustom, MjTextOverride])
+
+        assert not result_module.errors
+        assert not result_list.errors
+        module_actual_html = result_module.html
+        list_actual_html = result_list.html
+        assert_same_html(expected_html, module_actual_html, verbose=True)
+        assert_same_html(expected_html, list_actual_html, verbose=True)
+
 
 
 def load_expected_html(test_id):


### PR DESCRIPTION
Closes #29.

@FelixSchwarz You might consider this a rough draft, but it seems like it's working as expected. The test components could probably be more complex. Let me know what you think.

Components now support a `component_name` property (the majority of the file changes are just adding this one line).