### PR TITLE
Fix css-class on mj-section

### DIFF
--- a/mjml/elements/mj_column.py
+++ b/mjml/elements/mj_column.py
@@ -240,6 +240,8 @@ class MjColumn(BodyComponent):
             width='100%',
         )
         return f'''<table {table_attrs}>
-            {self.renderChildren(children, renderer=render_child)}
+            <tbody>
+                {self.renderChildren(children, renderer=render_child)}
+            </tbody>
         </table>'''
 

--- a/mjml/elements/mj_section.py
+++ b/mjml/elements/mj_section.py
@@ -199,7 +199,7 @@ class MjSection(BodyComponent):
     def renderSection(self):
         hasBackground = self.hasBackground()
 
-        wrapper_class = self.get_attr('css-class') if self.isFullWidth() else None
+        wrapper_class = None if self.isFullWidth() else self.get_attr('css-class')
         wrapper_attr_str = self.html_attrs(class_=wrapper_class, style='div')
 
         bg_div_start = f'<div {self.html_attrs(style="innerDiv")}>' if hasBackground else ''

--- a/tests/testdata/mj-section-with-css-class-expected.html
+++ b/tests/testdata/mj-section-with-css-class-expected.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+  <title></title>
+  <!--[if !mso]><!-->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <!--<![endif]-->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style type="text/css">
+    #outlook a {
+      padding: 0;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+
+    table,
+    td {
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+
+    img {
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+    }
+
+    p {
+      display: block;
+      margin: 13px 0;
+    }
+
+  </style>
+  <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+  <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+  <!--[if !mso]><!-->
+  <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+  <style type="text/css">
+    @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+
+  </style>
+  <!--<![endif]-->
+  <style type="text/css">
+    @media only screen and (min-width:480px) {
+      .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
+      }
+    }
+
+  </style>
+  <style media="screen and (min-width:480px)">
+    .moz-text-html .mj-column-per-100 {
+      width: 100% !important;
+      max-width: 100%;
+    }
+
+  </style>
+  <style type="text/css">
+  </style>
+  <style type="text/css">
+  </style>
+</head>
+
+<body style="word-spacing:normal;">
+  <div style="">
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="section-class-outlook" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div class="section-class" style="margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                  <tbody>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                        <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">some text</div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+  </div>
+</body>
+
+</html>

--- a/tests/testdata/mj-section-with-css-class.mjml
+++ b/tests/testdata/mj-section-with-css-class.mjml
@@ -1,0 +1,9 @@
+<mjml>
+  <mj-body>
+    <mj-section css-class="section-class">
+      <mj-column>
+        <mj-text>some text</mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/tests/upstream_alignment_test.py
+++ b/tests/upstream_alignment_test.py
@@ -33,6 +33,7 @@ class UpstreamAlignmentTest(TestCase):
         'mj-head-with-comment',
         'mj-image-with-empty-alt-attribute',
         'mj-image-with-href',
+        'mj-section-with-css-class',
         'mj-section-with-mj-class',
         'mj-section-with-background-url',
         'mj-font',
@@ -123,7 +124,7 @@ class UpstreamAlignmentTest(TestCase):
         body_actual = BeautifulSoup(result.html, 'html.parser').body
         actual_text = body_actual.get_text().strip()
         assert (expected_text == actual_text)
-        actual_html = (body_actual.select('table > tr > td > div')[0]).renderContents()
+        actual_html = (body_actual.select('.mj-column-per-100 div')[0]).renderContents()
         assert (b'foo <b>bar</b>.' == actual_html)
 
 


### PR DESCRIPTION
Logic for applying css-class has been fixed. Closes #35.

 Also adds in a missing `tbody` in mj-column.
<img width="376" alt="image" src="https://github.com/FelixSchwarz/mjml-stub/assets/2874325/6b19471a-6772-49de-a2af-08b02df03174">
